### PR TITLE
feat: 봉사자 신청현황 페이지 toast updatToast로 변경, onError 추가, toast 설명 폰트 속성 변경

### DIFF
--- a/apps/shelter/src/mocks/handlers/recruitment.ts
+++ b/apps/shelter/src/mocks/handlers/recruitment.ts
@@ -32,10 +32,12 @@ export const DUMMY_APPLICANT = {
   applicantStatus: 'APPROVED',
 };
 
-export const DUMMY_APPLICANT_LIST = Array.from(
-  { length: 9 },
-  () => DUMMY_APPLICANT,
-);
+export const DUMMY_APPLICANT_LIST = Array.from({ length: 9 }, (_, index) => {
+  return {
+    ...DUMMY_APPLICANT,
+    volunteerName: !(index % 2) ? '김철수' : '김영희',
+  };
+});
 
 export const handlers = [
   http.get('/shelters/recruitments', async () => {
@@ -58,6 +60,32 @@ export const handlers = [
     async () => {
       await delay(200);
       return HttpResponse.json({}, { status: 200 });
+    },
+  ),
+  http.patch(
+    '/shelters/recruitments/:recruitmentId/applicants/:applicantId',
+    async () => {
+      await delay(200);
+      return HttpResponse.json(
+        {
+          errorCode: 'AF301',
+          message: '해당 모집글에 대해 권한이 없습니다',
+        },
+        { status: 403 },
+      );
+    },
+  ),
+  http.patch(
+    '/shelters/recruitments/:recruitmentId/applicants/:applicantId',
+    async () => {
+      await delay(200);
+      return HttpResponse.json(
+        {
+          errorCode: 'AF401',
+          message: '해당 모집글을 신청한 봉사자가 아닙니다',
+        },
+        { status: 404 },
+      );
     },
   ),
   http.get('/shelters/recruitments/:recruitmentId/applicants', async () => {

--- a/apps/shelter/src/pages/manage/apply/_components/ManageApplyItem.tsx
+++ b/apps/shelter/src/pages/manage/apply/_components/ManageApplyItem.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Label from 'shared/components/Label';
 import { PERSON_GENDER_KOR } from 'shared/constants/gender';
 import { getAge } from 'shared/utils/date';
+import { updateToast } from 'shared/utils/toast';
 
 import { updateShelterRecruitmentApplicant } from '@/apis/recruitment';
 import CkCheck from '@/assets/CkCheck';
@@ -34,6 +35,7 @@ export default function ManageApplyItem({
   },
 }: ManageApplyItemProps) {
   const toast = useToast();
+  const manageApplyId = 'manage-apply';
   const queryClient = useQueryClient();
   const { mutate } = useMutation({
     mutationFn: (data: RecruitmentApplicantUpdateRequest) =>
@@ -47,12 +49,55 @@ export default function ManageApplyItem({
         ? APPLICANT_STATUS_KOR.APPROVE
         : APPLICANT_STATUS_KOR.REFUSE;
 
-      toast({
-        position: 'top',
-        description: `${volunteerName}님의 봉사신청을 ${descriptionStatus}했습니다`,
-        status: 'success',
-        duration: 1000,
-        isClosable: true,
+      toast.close(manageApplyId);
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      updateToast({
+        toast,
+        toastId: manageApplyId,
+        toastOptions: {
+          position: 'top',
+          description: (
+            <Text w="100%">
+              <Text as="span" fontWeight="bold">
+                {volunteerName}
+              </Text>
+              님의 신청을{` `}
+              <Text as="span" fontWeight="bold">
+                {descriptionStatus}
+              </Text>
+              했습니다
+            </Text>
+          ),
+          status: 'success',
+          duration: 1500,
+          isClosable: true,
+        },
+      });
+    },
+    onError: async (error) => {
+      toast.close(manageApplyId);
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      updateToast({
+        toast,
+        toastId: manageApplyId,
+        toastOptions: {
+          position: 'top',
+          description: (
+            <Text>
+              <Text as="span" fontWeight="bold">
+                {volunteerName}
+              </Text>
+              님은 {error.response?.data.message}
+            </Text>
+          ),
+          status: 'error',
+          duration: 1500,
+          isClosable: true,
+        },
       });
     },
   });


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #328 

## 📗 구현 내용 <!-- 이슈에 작성한 작업 외 다른 작업을 진행했다면 작성해주세요 -->

* [feat(shelter): 봉사 신청 상태 수정 msw에 403, 404 추가](https://github.com/anifriends/frontend/commit/737bec7fe6c05d328cfdfb68ac4c5c7a2604fd95)
* [refactor(shelter): updateToast로, toast 설명의 fontWeight 변경, useMutation에 onError 추가](https://github.com/anifriends/frontend/commit/7e3be70631c258f99fdd0115956fe7848248647e) 

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

https://github.com/anifriends/frontend/assets/66409882/d26ec3e8-2923-420b-bca7-96b514705dd8

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

신청 상태가 수정되면 toast가 생성되어 밀려 ux적으로 불편할 수 있는 상황을 고려하여 toast id를 지정하여 toast는 하나만 생성이 되게끔 구현하였습니다. 
